### PR TITLE
refactor: use relative data paths for fetch requests

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -32,7 +32,7 @@ import { TimelineRenderer } from './visualizations/TimelineRenderer.js';
 import { ChartJSRenderer } from './visualizations/ChartJSRenderer.js';
 
 // Utility imports
-import { TOTAL_SLIDES, TOTAL_SECTIONS, PERFORMANCE_TARGETS } from './utils/constants.js';
+import { TOTAL_SLIDES, TOTAL_SECTIONS, PERFORMANCE_TARGETS, DATA_PATHS } from './utils/constants.js';
 import * as helpers from './utils/helpers.js';
 
 class PresentationApp {
@@ -66,7 +66,7 @@ class PresentationApp {
 
             try {
                 await this.citationManager.initialize({
-                    dataPath: '/data/citations.json',
+                    dataPath: DATA_PATHS.CITATIONS,
                     locale: 'ko',
                     validateOnLoad: false
                 });
@@ -207,10 +207,10 @@ class PresentationApp {
         try {
             // Try to load data files if they exist
             const dataFiles = [
-                '/data/slides.json',
-                '/data/sections.json',
-                '/data/citations.json',
-                '/data/visualizations.json'
+                DATA_PATHS.SLIDES,
+                DATA_PATHS.SECTIONS,
+                DATA_PATHS.CITATIONS,
+                DATA_PATHS.VISUALIZATIONS
             ];
 
             for (const file of dataFiles) {

--- a/js/core/SlideManager.js
+++ b/js/core/SlideManager.js
@@ -10,7 +10,8 @@ import {
     PRELOAD_RANGE,
     PERFORMANCE_TARGETS,
     ERROR_MESSAGES,
-    SECTIONS
+    SECTIONS,
+    DATA_PATHS
 } from '../utils/constants.js';
 
 import { performance as perfHelpers } from '../utils/helpers.js';
@@ -87,7 +88,7 @@ export class SlideManager {
      */
     async loadSlidesData() {
         try {
-            const response = await fetch('/data/slides.json');
+            const response = await fetch(DATA_PATHS.SLIDES);
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}: ${response.statusText}`);
             }
@@ -104,7 +105,7 @@ export class SlideManager {
      */
     async loadSectionsData() {
         try {
-            const response = await fetch('/data/sections.json');
+            const response = await fetch(DATA_PATHS.SECTIONS);
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}: ${response.statusText}`);
             }
@@ -121,7 +122,7 @@ export class SlideManager {
      */
     async loadVisualizationsData() {
         try {
-            const response = await fetch('/data/visualizations.json');
+            const response = await fetch(DATA_PATHS.VISUALIZATIONS);
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}: ${response.statusText}`);
             }
@@ -138,7 +139,7 @@ export class SlideManager {
      */
     async loadCitationsData() {
         try {
-            const response = await fetch('/data/citations.json');
+            const response = await fetch(DATA_PATHS.CITATIONS);
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}: ${response.statusText}`);
             }

--- a/js/utils/constants.js
+++ b/js/utils/constants.js
@@ -63,6 +63,16 @@ export const DATA_CONFIG = {
     retryDelay: 1000
 };
 
+// Data Paths
+export const DATA_PATHS = Object.freeze({
+    BASE: 'data',
+    SLIDES: 'data/slides.json',
+    SECTIONS: 'data/sections.json',
+    VISUALIZATIONS: 'data/visualizations.json',
+    CITATIONS: 'data/citations.json',
+    METADATA: 'data/metadata.json'
+});
+
 // Citation Configuration
 export const CITATION_CONFIG = {
     style: 'apa',                // Citation style: apa, mla, chicago


### PR DESCRIPTION
## 요약
- 데이터 경로 상수(DATA_PATHS)를 추가해 공통 경로를 관리합니다.
- SlideManager와 CitationManager 초기화에서 절대 경로 대신 DATA_PATHS를 사용하도록 수정했습니다.
- 초기 데이터 로딩 루틴에서 동일한 상수를 적용하여 GitHub Pages 하위 경로에서도 JSON을 불러오도록 개선했습니다.

## 테스트
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68d1f3e1824883298d9afe43388a5094